### PR TITLE
Fixes CVE-2023-49569

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,19 +22,19 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/cpython"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pip"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pipenv"
-    version = "1.19.0"
+    version = "1.21.0"
 
   [[order.group]]
     id = "paketo-buildpacks/pipenv-install"
-    version = "0.6.18"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"
@@ -69,15 +69,15 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/cpython"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pip"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pip-install"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"
@@ -112,11 +112,11 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/miniconda"
-    version = "0.8.5"
+    version = "0.9.0"
 
   [[order.group]]
     id = "paketo-buildpacks/conda-env-update"
-    version = "0.7.12"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"
@@ -151,11 +151,11 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/cpython"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pip"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"
@@ -163,11 +163,11 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/poetry"
-    version = "0.6.5"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/poetry-install"
-    version = "0.3.17"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/poetry-run"
@@ -202,19 +202,19 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/cpython"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/pip"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/poetry"
-    version = "0.6.5"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/poetry-install"
-    version = "0.3.17"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"
@@ -249,7 +249,7 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/cpython"
-    version = "5.3"
+    version = "5.3-sp"
 
   [[order.group]]
     id = "paketo-buildpacks/python-start"

--- a/package.toml
+++ b/package.toml
@@ -3,28 +3,28 @@
   uri = "build/buildpack.tgz"
 
 [[dependencies]]
-  uri = "docker://quay.io/plotly/paketo-buildpacks-cpython:5.3.0b3"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-cpython:5.3-sp"
 
 [[dependencies]]
-  uri = "docker://quay.io/plotly/paketo-buildpacks-pip:5.3.0b2"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-pip:5.3-sp"
 
 [[dependencies]]
-  uri = "docker://gcr.io/paketo-buildpacks/pipenv:1.19.0"
+  uri = "docker://gcr.io/paketo-buildpacks/pipenv:1.21.0"
 
 [[dependencies]]
-  uri = "docker://gcr.io/paketo-buildpacks/pipenv-install:0.6.18"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-pipenv-install:5.3-sp"
 
 [[dependencies]]
-  uri = "docker://quay.io/plotly/paketo-buildpacks-pip-install:5.3.0b3"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-pip-install:5.3-sp"
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/python-start:0.14.14"
 
 [[dependencies]]
-  uri = "docker://gcr.io/paketo-buildpacks/miniconda:0.8.5"
+  uri = "docker://gcr.io/paketo-buildpacks/miniconda:0.9.0"
 
 [[dependencies]]
-  uri = "docker://gcr.io/paketo-buildpacks/conda-env-update:0.7.12"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-conda-env-update:5.3-sp"
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:5.6.4"
@@ -36,10 +36,10 @@
   uri = "docker://gcr.io/paketo-buildpacks/ca-certificates:3.6.3"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/poetry@0.6.5"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-poetry:5.3-sp"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/poetry-install@0.3.17"
+  uri = "docker://quay.io/plotly/paketo-buildpacks-poetry-install:5.3-sp"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/poetry-run@0.4.21"


### PR DESCRIPTION
New image available at `quay.io/plotly/paketo-buildpacks-python:5.3-sp`

Related PRs:
- https://github.com/plotly/paketo-buildpacks_poetry-install/pull/1
- https://github.com/plotly/paketo-buildpacks_poetry/pull/1
- https://github.com/plotly/paketo-buildpacks_pipenv-install/pull/1
- https://github.com/plotly/paketo-buildpacks_cpython/pull/7
- https://github.com/plotly/paketo-buildpacks_pip/pull/6
- https://github.com/plotly/pip-install/pull/6
- https://github.com/paketo-buildpacks/conda-env-update/pull/401